### PR TITLE
chore(deps): add libxtst-dev to Build-Depends for XTest fallback

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5-gtk (5.1.5-1deepin2) unstable; urgency=medium
+
+  * debian/control: Add libxtst-dev to Build-Depends for XTest fallback.
+
+ -- Wang Yu <wangyu@uniontech.com>  Tue, 24 Jun 2026 00:00:00 +0800
+
 fcitx5-gtk (5.1.5-1deepin1) unstable; urgency=medium
 
   * Add XTest key injection fallback for Chromium password fields.

--- a/debian/control
+++ b/debian/control
@@ -19,6 +19,7 @@ Build-Depends:
  libgtk-4-dev,
  libgtk2.0-dev,
  libx11-dev,
+ libxtst-dev,
  libxkbcommon-dev,
  libxkbcommon-x11-dev,
  pkgconf,


### PR DESCRIPTION
Add libxtst-dev to provide xtst pkg-config and XTest headers required by the Chromium password field XTest key injection fallback.

为 XTest 按键注入兜底补齐构建依赖,新增 libxtst-dev 提供 xtst pkg-config 及 XTest 头文件。

Log: 补齐 libxtst-dev 构建依赖
PMS: TASK-391451
Influence: 修复 XTest 兜底特性的构建依赖缺失,X11 环境下 Chromium 密码框方可经虚拟键盘输入。