### PR TITLE
fix: disable key snooper for deepin browser

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5-gtk (5.1.5-1deepin3) unstable; urgency=medium
+
+  * Add 0002-disable-snooper-for-deepin-browser.patch: add deepin browser to NO_SNOOPER_APPS.
+
+ -- Wang Yu <wangyu@uniontech.com>  Tue, 24 Jun 2026 00:00:00 +0800
+
 fcitx5-gtk (5.1.5-1deepin2) unstable; urgency=medium
 
   * debian/control: Add libxtst-dev to Build-Depends for XTest fallback.

--- a/debian/patches/0002-disable-snooper-for-deepin-browser.patch
+++ b/debian/patches/0002-disable-snooper-for-deepin-browser.patch
@@ -1,0 +1,23 @@
+Description: disable key snooper for deepin browser
+ Deepin browser is a Chromium-based browser, but its process name is
+ "browser", so it does not match the existing chrome/chromium snooper
+ blacklist. Add an exact match for it to the default list so it uses the same
+ GTK IM event path as other Chromium-family browsers without matching unrelated
+ application names that merely contain "browser".
+Author: Wang Yu <wangyu@uniontech.com>
+Forwarded: not-needed
+Last-Update: 2026-06-24
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 04e8e15..0d47df8 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -18,7 +18,7 @@ option(ENABLE_GTK4_IM_MODULE "Enable GTK4 IM Module" ON)
+ option(ENABLE_SNOOPER "Enable Key Snooper for gtk app" ON)
+ option(BUILD_ONLY_PLUGIN "Build only IM Module" OFF)
+ 
+-set(NO_SNOOPER_APPS ".*chrome.*,.*chromium.*,firefox.*,Do.*"
++set(NO_SNOOPER_APPS ".*chrome.*,.*chromium.*,^browser$,firefox.*,Do.*"
+     CACHE STRING "Disable Key Snooper for following app by default.")
+ set(NO_PREEDIT_APPS "gvim.*" CACHE STRING "Disable preedit for follwing app by default.")
+ set(SYNC_MODE_APPS "firefox.*" CACHE STRING "Use sync mode for following app by default.")

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-xtest-fallback-for-forward-key.patch
+0002-disable-snooper-for-deepin-browser.patch


### PR DESCRIPTION
Add deepin browser (^browser$) to NO_SNOOPER_APPS so it uses GTK IM event path like other Chromium-family browsers. Exact match avoids matching unrelated apps containing "browser".

将 deepin 浏览器（^browser$）加入 NO_SNOOPER_APPS，使其与其他
Chromium 系浏览器一样走 GTK IM 事件路径。使用精确匹配避免误伤
名称含 browser 的无关应用。

Log: 添加 deepin 浏览器到 NO_SNOOPER_APPS 黑名单
PMS: TASK-391451
Influence: deepin 浏览器进程名为 browser，此前未匹配 chrome/chromium 黑名单导致走 snooper 路径，加入后走 GTK IM 事件路径，修复输入法在浏览器中的事件处理。